### PR TITLE
Made oversample setable and getable

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -22,6 +22,10 @@ func _ready():
 #		openhmd_config.init_tracking_device(1)
 #		openhmd_config.init_controller_device(2)
 #		openhmd_config.init_controller_device(3)
+
+		# check oversample
+		print("Oversample was: " + str(openhmd_config.get_oversample()))
+		openhmd_config.set_oversample(1.5)
 		
 		# and tell our viewport to render
 		get_viewport().arvr = true

--- a/src/ARVRInterface.c
+++ b/src/ARVRInterface.c
@@ -133,7 +133,14 @@ godot_vector2 godot_arvr_get_render_targetsize(const void *p_data) {
 		// this should never ever ever ever happen, just being paranoid....
 	} else if (openhmd_data->ohmd_ctx != NULL) {
 			if (openhmd_data->hmd_device != NULL) {
-				api->godot_vector2_new(&size, openhmd_data->width * openhmd_data->oversample_scale, openhmd_data->height * openhmd_data->oversample_scale);
+				// use floats so we can multiply
+				float width = openhmd_data->width;
+				float height = openhmd_data->height;
+
+				width = floor(width * openhmd_data->oversample);
+				height = floor(height * openhmd_data->oversample);
+
+				api->godot_vector2_new(&size, (int) width, (int) height);
 			} else {
 				/* just return something so we can show something instead of crashing */
 				api->godot_vector2_new(&size, 600, 900);

--- a/src/godot_openhmd.c
+++ b/src/godot_openhmd.c
@@ -109,4 +109,23 @@ void GDN_EXPORT godot_nativescript_init(void *p_handle) {
 
 		nativescript_api->godot_nativescript_register_method(p_handle, "OpenHMDConfig", "init_controller_device", attributes, get_data);
 	}
+
+	{
+		godot_instance_method get_data = { NULL, NULL, NULL };
+		get_data.method = &openhmd_config_get_oversample;
+
+		godot_method_attributes attributes = { GODOT_METHOD_RPC_MODE_DISABLED };
+
+		nativescript_api->godot_nativescript_register_method(p_handle, "OpenHMDConfig", "get_oversample", attributes, get_data);
+	}
+
+	{
+		godot_instance_method get_data = { NULL, NULL, NULL };
+		get_data.method = &openhmd_config_set_oversample;
+
+		godot_method_attributes attributes = { GODOT_METHOD_RPC_MODE_DISABLED };
+
+		nativescript_api->godot_nativescript_register_method(p_handle, "OpenHMDConfig", "set_oversample", attributes, get_data);
+	}
+
 }

--- a/src/openhmd_config.c
+++ b/src/openhmd_config.c
@@ -184,3 +184,34 @@ GDCALLINGCONV godot_variant openhmd_config_init_controller_device(godot_object *
 
 	return ret;
 };
+
+GDCALLINGCONV godot_variant openhmd_config_get_oversample(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	godot_variant ret;
+
+	if (p_user_data == NULL || openhmd_data != p_user_data) {
+		// this should never ever ever ever happen, just being paranoid....
+		api->godot_variant_new_real(&ret, 1.0);
+	} else {
+		api->godot_variant_new_real(&ret, openhmd_get_oversample());
+	}
+
+	return ret;
+}
+
+GDCALLINGCONV godot_variant openhmd_config_set_oversample(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	godot_variant ret;
+
+	if (p_user_data == NULL || openhmd_data != p_user_data) {
+		// this should never ever ever ever happen, just being paranoid....
+		api->godot_variant_new_bool(&ret, false);
+	} else if (p_num_args == 0) {
+		// no arguments given
+		api->godot_variant_new_bool(&ret, false);
+	} else {
+		float new_value = api->godot_variant_as_real(p_args[0]);
+		openhmd_set_oversample(new_value);
+		api->godot_variant_new_bool(&ret, true);
+	}
+
+	return ret;
+}

--- a/src/openhmd_config.h
+++ b/src/openhmd_config.h
@@ -15,5 +15,7 @@ GDCALLINGCONV godot_variant openhmd_config_close_hmd_device(godot_object *p_inst
 GDCALLINGCONV godot_variant openhmd_config_init_tracking_device(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 GDCALLINGCONV godot_variant openhmd_config_close_tracking_device(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 GDCALLINGCONV godot_variant openhmd_config_init_controller_device(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant openhmd_config_get_oversample(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant openhmd_config_set_oversample(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
 #endif /* !OPENHMD_CONFIG_H */

--- a/src/openhmd_data.c
+++ b/src/openhmd_data.c
@@ -16,7 +16,7 @@ openhmd_data_struct *get_openhmd_data() {
 		openhmd_data->num_devices = 0;
 		openhmd_data->width = 0;
 		openhmd_data->height = 0;
-		openhmd_data->oversample_scale = 2;
+		openhmd_data->oversample = 2.0;
 		openhmd_data->ohmd_ctx = NULL;
 		openhmd_data->ohmd_settings = NULL;
 		openhmd_data->hmd_device = NULL;
@@ -254,3 +254,20 @@ bool openhmd_init_controller_device(int p_device) {
 		return true;
 	};
 };
+
+float openhmd_get_oversample() {
+	if (openhmd_data == NULL) {
+		// Not yet initialised!
+		return 1.0;
+	} else {
+		return openhmd_data->oversample;
+	}
+}
+
+void openhmd_set_oversample(float p_new_value) {
+	if (openhmd_data == NULL) {
+		// Not yet initialised!
+	} else {
+		openhmd_data->oversample = p_new_value;		
+	}
+}

--- a/src/openhmd_data.h
+++ b/src/openhmd_data.h
@@ -19,7 +19,7 @@ typedef struct openhmd_data_struct {
 	bool do_auto_init_device_zero;
 	int num_devices;
 	int width, height;
-	int oversample_scale;
+	float oversample;
 	ohmd_context *ohmd_ctx; /* OpenHMD context we're using */
 	ohmd_device_settings *ohmd_settings; /* Settings we're using */
 	ohmd_device *hmd_device; /* HMD device we're rendering to */
@@ -41,6 +41,8 @@ void openhmd_close_tracking_device();
 bool openhmd_init_tracking_device(int p_device);
 void openhmd_close_controller_device(int p_index);
 bool openhmd_init_controller_device(int p_device);
+float openhmd_get_oversample();
+void openhmd_set_oversample(float p_new_value);
 
 #endif /* !OPENHMD_DATA_H */
 


### PR DESCRIPTION
Added an option to our config object so we can set and get the oversample setting:

```
print("Oversample: " + str(openhmd_config.get_oversample()))
openhmd_config.set_oversample(1.5)
```