### PR TITLE
Fixed crash issue in 3.1

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -100,6 +100,7 @@ flags_use_point_size = false
 flags_world_triplanar = false
 flags_fixed_size = false
 flags_albedo_tex_force_srgb = false
+flags_do_not_receive_shadows = false
 vertex_color_use_as_albedo = false
 vertex_color_is_srgb = false
 params_diffuse_mode = 1
@@ -144,20 +145,19 @@ _sections_unfolded = [ "Albedo" ]
 [sub_resource type="PlaneMesh" id=4]
 
 material = SubResource( 3 )
+custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
+flip_faces = false
 size = Vector2( 10, 10 )
 subdivide_width = 10
 subdivide_depth = 10
 
 [node name="Main" type="Spatial" index="0"]
-
 script = ExtResource( 1 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." index="0"]
-
 environment = SubResource( 2 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="." index="1"]
-
 transform = Transform( 0.623013, -0.733525, 0.271654, 0.321394, 0.55667, 0.766044, -0.713134, -0.389948, 0.582563, 0, 100, 0 )
 layers = 1
 light_color = Color( 1, 1, 1, 1 )
@@ -185,13 +185,11 @@ directional_shadow_max_distance = 200.0
 _sections_unfolded = [ "Transform" ]
 
 [node name="ARVROrigin" type="ARVROrigin" parent="." index="2"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.85, 0 )
 world_scale = 1.0
 _sections_unfolded = [ "Transform" ]
 
 [node name="ARVRCamera" type="ARVRCamera" parent="ARVROrigin" index="0"]
-
 keep_aspect = 1
 cull_mask = 1048575
 environment = null
@@ -207,7 +205,6 @@ far = 100.0
 _sections_unfolded = [ "Transform" ]
 
 [node name="Ground" type="MeshInstance" parent="." index="3"]
-
 transform = Transform( 100, 0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0 )
 layers = 1
 material_override = null
@@ -224,5 +221,4 @@ material/0 = null
 _sections_unfolded = [ "Transform" ]
 
 [node name="Table" parent="." index="4" instance=ExtResource( 3 )]
-
 

--- a/demo/addons/godot-openhmd/godot_openhmd.gdnlib
+++ b/demo/addons/godot-openhmd/godot_openhmd.gdnlib
@@ -3,6 +3,7 @@
 singleton=true
 load_once=true
 symbol_prefix="godot_"
+reloadable=false
 
 [entry]
 
@@ -12,6 +13,6 @@ OSX="res://addons/godot-openhmd/bin/osx/libgodot_openhmd.dylib"
 
 [dependencies]
 
-X11.64=[]
-Windows=[]
-OSX.64=[]
+X11.64=[  ]
+Windows=[  ]
+OSX.64=[  ]

--- a/src/GodotCalls.h
+++ b/src/GodotCalls.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 // forward declarations
 extern const godot_gdnative_core_api_struct *api;


### PR DESCRIPTION
@TheOnlyJoey this was all there was too that crash, a new feature in 3.1 allows the editor to unload GDNative plugins when it looses focus, and reload it when focus is regained. That behavior kills ARVR interfaces as the interface needs to persist.
Lucky its a simple new switch that 3.0 will ignore and 3.1 happily listens to